### PR TITLE
export start_link/7

### DIFF
--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -21,7 +21,7 @@
         (is_integer((ReconnectSleep)) orelse (ReconnectSleep) =:= no_reconnect)).
 
 -export([start_link/0, start_link/1, start_link/2, start_link/3, start_link/4,
-         start_link/5, start_link/6, stop/1, q/2, q/3, qp/2, qp/3,
+         start_link/5, start_link/6, start_link/7, stop/1, q/2, q/3, qp/2, qp/3,
          q_noreply/2, qp_noreply/2, q_async/2, q_async/3, qp_async/2, qp_async/3]).
 
 %% Exported for testing


### PR DESCRIPTION
Exported start_link/7 to use Transport and ConnectTimeout variables together when different from the default. 