### PR TITLE
Reset response queue on lost socket connection to redis

### DIFF
--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -427,7 +427,8 @@ handle_socket_removal(Reason, State) ->
         ReconnectSleep ->
             flush_socket_messages(State),
             _ = erlang:send_after(ReconnectSleep, self(), connect),
-            NewState = State#state{ socket = undefined },
+            NewState = State#state{ socket = undefined,
+                                    queue = queue:new()},
             {noreply, NewState}
     end.
 


### PR DESCRIPTION
In cases where redis-server gets blocked for some reason,
there'll be for sure outstanding replies that haven't arrived
yet. If redis then dies (or most likely, have it failover to a replica)
then the connection is lost, at this point the queue of pending replies
must also be cleared otherwise when the connection is re-established the
state machine will be out of sync and requests will consistently time
out.