### PR TITLE
Fix rebar3 -related (via certifi and code:.) compilation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- [dep.] `tls_certificate_check` from 1.1.1 to 1.2.0 [Paulo Oliveira]
+
+### Fixed
+
+- `rebar3` + `certifi` (now indirectly removed) compilation issues [Paulo Oliveira]
+
 ## [2.4.1] - 2021-03-04
 
 ### Removed

--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 %% == Dependencies and plugins ==
 
 {deps, [
-    {tls_certificate_check, "1.1.1"}
+    {tls_certificate_check, "1.2.0"}
 ]}.
 
 {project_plugins, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,19 +1,13 @@
 {"1.2.0",
-[{<<"certifi">>,{pkg,<<"certifi">>,<<"2.5.3">>},1},
- {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},1},
- {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.6">>},1},
+[{<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.6">>},1},
  {<<"tls_certificate_check">>,
-  {pkg,<<"tls_certificate_check">>,<<"1.1.1">>},
+  {pkg,<<"tls_certificate_check">>,<<"1.2.0">>},
   0}]}.
 [
 {pkg_hash,[
- {<<"certifi">>, <<"70BDD7E7188C804F3A30EE0E7C99655BC35D8AC41C23E12325F36AB449B70651">>},
- {<<"parse_trans">>, <<"09765507A3C7590A784615CFD421D101AEC25098D50B89D7AA1D66646BC571C1">>},
  {<<"ssl_verify_fun">>, <<"CF344F5692C82D2CD7554F5EC8FD961548D4FD09E7D22F5B62482E5AEAEBD4B0">>},
- {<<"tls_certificate_check">>, <<"2B6647FF87A8291A982458883DCA7D5B39BA305835FE4342BF22E5476D3998C5">>}]},
+ {<<"tls_certificate_check">>, <<"0659E00301A0907A049A35E4E3F7FAC4E2E26783EB6CCD54B917F26638A6BE9D">>}]},
 {pkg_hash_ext,[
- {<<"certifi">>, <<"ED516ACB3929B101208A9D700062D520F3953DA3B6B918D866106FFA980E1C10">>},
- {<<"parse_trans">>, <<"17EF63ABDE837AD30680EA7F857DD9E7CED9476CDD7B0394432AF4BFC241B960">>},
  {<<"ssl_verify_fun">>, <<"BDB0D2471F453C88FF3908E7686F86F9BE327D065CC1EC16FA4540197EA04680">>},
- {<<"tls_certificate_check">>, <<"08FD94D68E5C80E172529B9BB89715C95747FF55447A2C833A1205564FA7BFEE">>}]}
+ {<<"tls_certificate_check">>, <<"5435F4058141CB99B3F7CB15F84B9ACA320CF143F9CB3CC32840A4BC366D6FF7">>}]}
 ].


### PR DESCRIPTION
This fixes (by indirect removal of `certifi`) compilations issues we had with `rebar3` 3.14.4, related with https://github.com/erlang/rebar3/pull/2514.