### PR TITLE
Use up-to-date CAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `rebar3_hank [Paulo Oliveira]
+- `rebar3_hank` [Paulo Oliveira]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - CI container approach to `setup-beam` with cache [Paulo Oliveira]
+- CA bundles, to base them on the latest Mozilla Included CA Certificate List [Guilherme Andrade]
 
 ## [2.4.2] - 2021-03-15
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %% == Erlang Compiler ==
 
-{minimum_otp_vsn, "21.3"}.
+{minimum_otp_vsn, "22.0"}.
 
 {erl_opts, [
     debug_info,
@@ -13,7 +13,7 @@
 %% == Dependencies and plugins ==
 
 {deps, [
-    {tls_certificate_check, "1.2.0"}
+    {tls_certificate_check, "1.7.0"}
 ]}.
 
 {project_plugins, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,13 +1,13 @@
 {"1.2.0",
 [{<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.6">>},1},
  {<<"tls_certificate_check">>,
-  {pkg,<<"tls_certificate_check">>,<<"1.2.0">>},
+  {pkg,<<"tls_certificate_check">>,<<"1.7.0">>},
   0}]}.
 [
 {pkg_hash,[
  {<<"ssl_verify_fun">>, <<"CF344F5692C82D2CD7554F5EC8FD961548D4FD09E7D22F5B62482E5AEAEBD4B0">>},
- {<<"tls_certificate_check">>, <<"0659E00301A0907A049A35E4E3F7FAC4E2E26783EB6CCD54B917F26638A6BE9D">>}]},
+ {<<"tls_certificate_check">>, <<"A707839AAFB31C1888F86EB5484617DE3B3909A508521AD4F52641375DDC2231">>}]},
 {pkg_hash_ext,[
  {<<"ssl_verify_fun">>, <<"BDB0D2471F453C88FF3908E7686F86F9BE327D065CC1EC16FA4540197EA04680">>},
- {<<"tls_certificate_check">>, <<"5435F4058141CB99B3F7CB15F84B9ACA320CF143F9CB3CC32840A4BC366D6FF7">>}]}
+ {<<"tls_certificate_check">>, <<"B5014C39239DEA00197C6C315E5178C0B112DF34E75C2BDD5939B95564E369CA">>}]}
 ].


### PR DESCRIPTION
### Situation

A number of CAs were either [added or removed](https://github.com/g-andrade/tls_certificate_check/blob/1.7.0/CHANGELOG.md#170---2021-07-08) over the last few months.

### Importance

If a Redis TLS endpoint we use starts serving TLS with a certificate signed by one of the new CAs, we'll run into issues.

### Caveat

This PR also drops support for OTP 21 since `tls_certificate_check` only supports the last 3 OTP versions.